### PR TITLE
UX: Group avatar flair follows avatar border radius

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -33,7 +33,9 @@
 }
 
 // Avatars shape (round = 50%, square = 0%)
-.avatar {
+.avatar,
+.groups-boxes .group-box .group-avatar-flair .avatar-flair,
+.group-info .avatar-flair {
   border-radius: #{$avatars_border_radius} !important;
 }
 


### PR DESCRIPTION
On the group listing and group info screens the border radius of the avatar flair should be the same as that avatar border radius.